### PR TITLE
poetry stop looking for packages that don't exist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = ""
 authors = ["TRJackson998 <t.r.jackson998@gmail.com>"]
 readme = "README.md"
+packages = [
+    { include = "proxy_analyzer" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
Poetry expects to find a 'magic' package because the .toml file knows the name of my project is 'magic'. That isn't a package that exists at the moment, so `poetry install` fails. Tell it what package I do have and it succeeds.